### PR TITLE
Use Gtk:3 when Gtk:4 is installed

### DIFF
--- a/bin/kazam
+++ b/bin/kazam
@@ -29,8 +29,9 @@ import dbus.service
 from argparse import ArgumentParser
 from dbus.mainloop.glib import DBusGMainLoop
 
+import gi
+gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk
-
 
 class KazamService(dbus.service.Object):
 


### PR DESCRIPTION
Kazam doesn't specify which Gtk version to use. This corrects this issue which causes the error: `AttributeError: 'gi.repository.Gdk' object has no attribute 'CursorType'`

This PR Fixes #3